### PR TITLE
Pypy timeout fixes

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -31,6 +31,6 @@ jobs:
     - name: Generate Report
       run: |
         pip install coverage
-        python -m coverage run -m pytest -s tests
+        python -m coverage run -m pytest -vs tests
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -33,6 +33,6 @@ jobs:
     - name: Generate Report
       run: |
         pip install coverage
-        python -m coverage run -m pytest -s tests
+        python -m coverage run -m pytest -vs tests
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -394,6 +394,9 @@ def command_runner(
             # output_queue has finished sending data, so we catch the exit code
             while process.poll() is None:
                 __check_timeout(begin_time, timeout)
+            # Additional timeout check to make sure we don't return an exit code from processes
+            # that were killed because of timeout
+            __check_timeout(begin_time, timeout)
             exit_code = process.poll()
             return exit_code, output
 

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -419,6 +419,7 @@ def command_runner(
             if timeout and (datetime.now() - begin_time).total_seconds() > timeout:
                 kill_childs_mod(process.pid, itself=True, soft_kill=False)
                 timeout_dict["is_timeout"] = True
+                print('timeout thread', timeout_dict["is_timeout"])
                 break
             if process.poll() is not None:
                 break
@@ -438,6 +439,7 @@ def command_runner(
 
         # Let's create a mutable object since it will be shared with a thread
         timeout_dict = {"is_timeout": False}
+        print('timeout main', timeout_dict["is_timeout"])
 
         thread = threading.Thread(
             target=_timeout_check_thread,
@@ -455,6 +457,7 @@ def command_runner(
             while process.poll() is None:
                 sleep(MIN_RESOLUTION)
                 if timeout_dict["is_timeout"]:
+                    print('timeout monitor', timeout_dict["is_timeout"])
                     break
 
                 # We still need to use process.communicate() in this loop so we don't get stuck
@@ -471,7 +474,7 @@ def command_runner(
             except (TimeoutExpired, ValueError):
                 pass
             process_output = to_encoding(stdout, encoding, errors)
-
+            print('timeout monitor2', timeout_dict["is_timeout"])
             if timeout_dict["is_timeout"]:
                 raise TimeoutExpired(process, timeout, process_output)
 

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -423,7 +423,9 @@ def command_runner(
                 break
             if process.poll() is not None:
                 break
+            print('i am alive before')
             sleep(MIN_RESOLUTION)
+            print('i am alive after')
 
     def _monitor_process(
         process,  # type: Union[subprocess.Popen[str], subprocess.Popen]
@@ -482,6 +484,7 @@ def command_runner(
             except (TimeoutExpired, ValueError):
                 pass
             process_output = to_encoding(stdout, encoding, errors)
+            sleep(2)
             try:
                 is_timeout = timeout_queue.get_nowait()
             except queue.Empty:

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -406,19 +406,20 @@ def command_runner(
     def _timeout_check_thread(
         process,  # type: Union[subprocess.Popen[str], subprocess.Popen]
         timeout,  # type: int
-        timeout_dict,  # type: dict
     ):
         # type: (...) -> None
-
         """
         Since elder python versions don't have timeout, we need to manually check the timeout for a process
         """
+
+        nonlocal is_timeout
 
         begin_time = datetime.now()
         while True:
             if timeout and (datetime.now() - begin_time).total_seconds() > timeout:
                 kill_childs_mod(process.pid, itself=True, soft_kill=False)
-                timeout_dict["is_timeout"] = True
+                is_timeout = True
+                print('is_timeout thread', is_timeout)
                 break
             if process.poll() is not None:
                 break
@@ -436,12 +437,13 @@ def command_runner(
         Get stdout output and return it
         """
 
-        # Let's create a mutable object since it will be shared with a thread
-        timeout_dict = {"is_timeout": False}
+        # Let's use a nonlocal variable since it will be shared with a threaded function
+        nonlocal is_timeout
+        is_timeout = False
 
         thread = threading.Thread(
             target=_timeout_check_thread,
-            args=(process, timeout, timeout_dict),
+            args=(process, timeout),
         )
         thread.setDaemon(True)
         thread.start()
@@ -454,7 +456,7 @@ def command_runner(
             # Also it won't allow communicate() to get incomplete output on timeouts
             while process.poll() is None:
                 sleep(MIN_RESOLUTION)
-                if timeout_dict["is_timeout"]:
+                if is_timeout:
                     break
 
                 # We still need to use process.communicate() in this loop so we don't get stuck
@@ -471,8 +473,8 @@ def command_runner(
             except (TimeoutExpired, ValueError):
                 pass
             process_output = to_encoding(stdout, encoding, errors)
-
-            if timeout_dict["is_timeout"]:
+            print('is_timeout monitor', is_timeout)
+            if is_timeout:
                 raise TimeoutExpired(process, timeout, process_output)
 
             return exit_code, process_output
@@ -521,6 +523,8 @@ def command_runner(
             if method == "poller" or live_output:
                 exit_code, output = _poll_process(process, timeout, encoding, errors)
             else:
+                is_timeout = False
+                print('is_timeout main', is_timeout)
                 exit_code, output = _monitor_process(process, timeout, encoding, errors)
         except KbdInterruptGetOutput as exc:
             exit_code = -252

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -423,9 +423,7 @@ def command_runner(
                 break
             if process.poll() is not None:
                 break
-            print('i am alive before')
             sleep(MIN_RESOLUTION)
-            print('i am alive after')
 
     def _monitor_process(
         process,  # type: Union[subprocess.Popen[str], subprocess.Popen]
@@ -468,7 +466,7 @@ def command_runner(
                 else:
                     print('timeout monitor', is_timeout)
                     break
-
+                print('alive', thread.is_alive())
                 # We still need to use process.communicate() in this loop so we don't get stuck
                 # with poll() is not None even after process is finished
                 try:
@@ -476,7 +474,7 @@ def command_runner(
                 # ValueError is raised on closed IO file
                 except (TimeoutExpired, ValueError):
                     pass
-
+            print('alive', thread.is_alive())
             exit_code = process.poll()
             print('got exit code', exit_code)
             try:
@@ -484,7 +482,9 @@ def command_runner(
             except (TimeoutExpired, ValueError):
                 pass
             process_output = to_encoding(stdout, encoding, errors)
-            sleep(1.5)
+            if thread.is_alive():
+                sleep(1.5)
+            print('alive', thread.is_alive())
             try:
                 is_timeout = timeout_queue.get_nowait()
             except queue.Empty:

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -18,8 +18,8 @@ __intname__ = "command_runner"
 __author__ = "Orsiris de Jong"
 __copyright__ = "Copyright (C) 2015-2021 Orsiris de Jong"
 __licence__ = "BSD 3 Clause"
-__version__ = "1.2.0"
-__build__ = "2021090701"
+__version__ = "1.2.1"
+__build__ = "2021090901"
 
 import io
 import os

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -484,7 +484,7 @@ def command_runner(
             except (TimeoutExpired, ValueError):
                 pass
             process_output = to_encoding(stdout, encoding, errors)
-            sleep(2)
+            sleep(1.5)
             try:
                 is_timeout = timeout_queue.get_nowait()
             except queue.Empty:

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -82,7 +82,7 @@ def test_timeout_with_subtree_killing():
         print(output)
         end_time = datetime.now()
         elapsed_time = (end_time - begin_time).total_seconds()
-        assert elapsed_time < 2, 'It took more than 2 seconds for a timeout=1 command to finish with method {}'.format(method)
+        assert elapsed_time < 4, 'It took more than 2 seconds for a timeout=1 command to finish with method {}'.format(method)
         assert exit_code == -254, 'Exit code should be -254 on timeout with method {}'.format(method)
         assert 'Timeout' in output, 'Output should have timeout with method {}'.format(method)
 

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -72,7 +72,7 @@ def test_timeout_with_subtree_killing():
     Launch a subtree of long commands and see if timeout actually kills them in time
     """
     if os.name != 'nt':
-        cmd = 'echo "test" && sleep 30 && echo "done"'
+        cmd = 'echo "test" && sleep 5 && echo "done"'
     else:
         cmd = 'echo test && {} && echo done'.format(PING_CMD)
 


### PR DESCRIPTION
Well, all python implementations worked fine with the monitor method, except Pypy 3.7 which had race conditions between the timeout thread and the monitor function.
No way to replicate this locally, only happened on github actions, which made it a real pain to diagnose.
Anyway, we added a couple of extra checks to ensure we don't have a thread race going on...