### PR TITLE
Split streams

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -28,6 +28,6 @@ jobs:
         RUNNING_ON_GITHUB_ACTIONS: true
       run: |
         pip install pytest coverage
-        python -m coverage run -m pytest -vs tests
+        python -m coverage run -m pytest -vvs tests
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -32,6 +32,6 @@ jobs:
         RUNNING_ON_GITHUB_ACTIONS: true
       run: |
         pip install pytest coverage
-        python -m coverage run -m pytest -vs tests
+        python -m coverage run -m pytest -vvs tests
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # v1.4.0 - command and conquer them all
 
 ## Features
@@ -17,7 +16,7 @@
 
 ## Fixes
 
-- Fix unix command list didn't work with `shell=True`
+- Fix unix command provided as list didn't work with `shell=True`
 - Fixed more Python 2.7 UnicodedecodeErrors on corner case exceptions catches
 - Fixed python 2.7 TimeoutException output can fail with UnicodedecodeError
 - Fix Python 2.7 does not have subprocess.DEVNULL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,118 @@
+
+# v1.4.0 - command and conquer them all
+
+## Features
+
+- command_runner now has a `command_runner_threaded()` function which allows to run in background, but stil provide live stdout/stderr stream output via queues/callbacks
+- Refactor poller mode to allow multiple stdout / stderr stream redirectors
+    - Passing a queue.Queue() instance to stdout/stderr arguments will fill queue with live stream output
+	- Passing a function to stdout/stderr arguments will callback said function with live stream output
+	- Passing a string to stdout/stderr arguments will redirect stream into filename described by string
+- Added `split_stream` argument which will make command_runner return (exit_code, stdout, stderr) instead of (exit_code, output) tuple
+- Added `check_interval` argument which decides how much time we sleep between two checks, defaults to 0.05 seconds.
+  Lowering this improves responsiveness, but increases CPU usage. Default value should be more than reasaonable for most applications
+- Added `stop_on` argument which takes a function, which is called every `check_interval` and will interrupt execution if it returns True
+- Added `process_callback` argument which takes a function(process), which is called upon execution with a subprocess.Popen object as argument for optional external process control
+- Added more unit tests (stop_on, process_callback, stream callback / queues, to_null_redirections, split_streams)
+
+## Fixes
+
+- Fix unix command list didn't work with `shell=True`
+- Fixed more Python 2.7 UnicodedecodeErrors on corner case exceptions catches
+- Fixed python 2.7 TimeoutException output can fail with UnicodedecodeError
+- Fix Python 2.7 does not have subprocess.DEVNULL
+- Ensure output is always None if process didn't return any string on stdout/stderr on Python 2.7
+- Fix python 2.7 process.communicate() multiple calls endup without output (non blocking process.poll() needs communicate() when using shell=True)
+
+## Misc
+
+- Removed queue usage in monitor mode (needs lesser threads)
+- Optimized performance
+- Added new exit code -250 when queue/callbacks are used with monitor method or unknown method has been called
+- Optimized tests
+
+# v1.3.1 - command & conquer the standard out/err reloaded
+
+## Misc
+
+- Packaging fixes for Python 2.7 when using `pip install command_runner`
+
+# v1.3.0 - command & conquer the standard out/err
+
+## Features
+
+- Adds the possibility to redirect stdout/stderr to null with `stdout=False` or `stderr=False` arguments
+
+## Misc
+
+- Add python 3.10 to the test matrix
+
+# v1.2.1 - command (threads) & conquer
+
+## Fixes
+
+- Timeout race condition with pypy 3.7 (!) where sometimes exit code wasn't -254
+- Try to use signal.SIGTERM (if exists) to kill a process instead of os API that uses PID in order to prevent possible collision when process is already dead and another process with the same PID exists
+
+## Misc
+
+- Unit tests are more verbose
+- Black formatter is now enforced
+- Timeout tests are less strict to cope with some platform delays
+
+# v1.2.0 - command (runner) & conquer
+
+## Features
+
+- Added a new capture method (monitor)
+- There are now two distinct methods to capture output
+    - Spawning a thread to enforce timeouts, and using process.communicate() (monitor method)
+    - Spawning a thread to readlines from stdout pipe to an output queue, and reading from that output queue while enforcing timeouts (polller method)
+- On the fly output (live_output=True) option is now explicit (uses poller method only)
+- Returns partial stdout output when timeouts are reached
+- Returns partial stdout output when CTRL+C signal is received (only with poller method)
+
+## Fixes
+
+- CRITICAL: Fixed rare annoying but where output wasn't complete
+- Use process signals in favor of direct os.kill API to avoid potential race conditions when PID is reused too fast
+- Allow full process subtree killing on Windows & Linux, hence not blocking multiple commands like echo "test" && sleep 100 && echo "done"
+- Windows does not maintain an explicit process subtree, so we runtime walk processes to establish the child processes to kill. Obviously, orphaned processes cannot be killed that way.-
+
+## Misc
+
+- Adds a default 16K stdout buffer
+- Default command execution timeout is 3600s (1 hour)
+- Highly improved tests
+    - All tests are done for both capture methods
+    - Timeout tests are more accurate
+    - Added missing encoding tests
+    - 2500 rounds of file reading and comparaison are added to detect rare queue read misses
+
+# v0.7.0 (yanked - do not use; see v1.2.0 critical fixes) - The windows GUI
+
+## Features
+
+- Added threaded pipe reader (poller) in order to enforce timeouts on Windows GUI apps
+
+# v0.6.4 - Keep it working more
+
+## Fixes
+
+- Fixed possible encoding issue with Python < 3.4 and powershell containing non unicode output
+- More packaging fixes
+
+# v0.6.3 - keep_it_working
+
+## Fixes
+
+- Packaging fixes for Python 2.7
+
+# v0.6.2 - make_it_work
+
+## Fixes
+
+- Improve CI tests
+- Fixed possible use of `windows_no_window` with Python < 3.7 should not be allowed
+
+# v0.6.0 - Initial public release - make_it_simple

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # command_runner
-## A python tool for rapid platform agnostic command execution, live stdout/stderr output capture, and UAC/sudo elevation
+# Platform agnostic command execution, timed background jobs with live stdout/stderr output capture, and UAC/sudo elevation
 
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/netinvent/command_runner.svg)](http://isitmaintained.com/project/netinvent/command_runner "Percentage of issues still open")
@@ -13,7 +13,7 @@
 command_runner's purpose is to run external commands from python, just like subprocess on which it relies, 
 while solving various problems a developer may face among:
    - Handling of all possible subprocess.popen / subprocess.check_output scenarios / python versions in one handy function without encoding / timeout hassle
-   - Allow stdout/stderr stream output to be redirected to callback functions / output queues / files so you get output into your application while commands are running
+   - Allow stdout/stderr stream output to be redirected to callback functions / output queues / files so you get to handle output in your application while commands are running
    - Callback to optional stop check so we can stop execution from outside command_runner
    - Callback with optional process information so we get to control the process from outside command_runner
    - System agnostic functionality, the developer shouldn't carry the burden of Windows & Linux differences
@@ -29,22 +29,21 @@ It is also compatible with PyPy Python implementation.
 command_runner is a replacement package for subprocess.popen and subprocess.check_output
 The main promise command_runner can do is to make sure to never have a blocking command, and always get results.
 
-It works as wrapper for subprocess.popen and subprocess.check_output that solves:
+It works as wrapper for subprocess.popen and subprocess.communicate that solves:
    - Platform differences
       - Handle timeouts even for windows GUI applications that don't return anything to stdout
    - Python language version differences
       - Handle timeouts even on earlier Python implementations
       - Handle encoding even on earlier Python implementations
    - Keep the promise to always return an exit code (so we don't have to deal with exit codes and exception logic at the same time)
-   - Keep the promise to always return the command output regardless of the execution state (even with timeouts and keyboard interrupts)
+   - Keep the promise to always return the command output regardless of the execution state (even with timeouts, callback interrupts and keyboard interrupts)
    - Can show command output on the fly without waiting the end of execution (with `live_output=True` argument)
    - Can give command output on the fly to application by using queues or callback functions
    - Catch all possible exceptions and log them properly with encoding fixes
+   - Be compatible, and always return the same result regarless of platform
 
 command_runner also promises to properly kill commands when timeouts are reached, including spawned subprocesses of such commands.
 This specific behavior is achieved via psutil module, which is an optional dependency.
-
-
 
    
 ### command_runner in a nutshell
@@ -60,7 +59,7 @@ exit_code, output = command_runner('ping 127.0.0.1', timeout=30, encoding='utf-8
 ```
 
 
-## Guide
+## Guide to command_runner
 
 ### Setup
 
@@ -195,15 +194,22 @@ You may also pass any other subprocess.PIPE int values to `stdout` or `stderr` a
 - /dev/null or NUL
 
 If `stdout=False` and/or `stderr=False` argument(s) are given, command output will not be saved.
+stdout/stderr streams will be redirected to `/dev/null` or `NUL` depending on platform.
+
+Output will always be `None`. See `split_streams` for more details using multiple outputs.
 
 - files
 
 Giving `stdout` and/or `stderr` arguments a string, `command_runner` will consider the string to be a file path where stream output will be written live.
-Example (of course this also works with unix paths):
 
+Examples:
 ```python
 from command_runner import command_runner
-exit_code, output = command_runner('dir', stdout='C:/tmp/command_result', stderr='C:/tmp/command_error', shell=True)
+exit_code, output = command_runner('dir', stdout=r"C:/tmp/command_result", stderr=r"C:/tmp/command_error", shell=True)
+```
+```python
+from command_runner import command_runner
+exit_code, output = command_runner('dir', stdout='/tmp/stdout.log', stderr='/tmp/stderr.log', shell=True)
 ```
 
 Note that the output files will be encoded by default in UTF-8 for Unix and CP437 for windows.
@@ -316,7 +322,7 @@ Example:
 from command_runner import command_runner
 
 def some_function():
-    return True if my_conditions_are_met
+    return True if we_must_stop_execution
 exit_code, output = command_runner('ping 127.0.0.1', stop_on=some_function)
 ```
 
@@ -342,28 +348,47 @@ def show_process_info(process):
 exit_code, output = command_runner('ping 127.0.0.1', process_callback=show_process_info)
 ```
 
+#### Split stdout and stderr
+
+By default, `command_runner` returns a tuple like `(exit_code, output)` in which output contains both stdout and stderr stream outputs.
+You can alter that behavior by using argument `split_stream=True`.
+In that case, `command_runner` will return a tuple like `(exit_code, stdout, stderr)`.
+
+Example:
+```python
+from command_runner import command_runner
+
+exit_code, stdout, stderr = command_runner('ping 127.0.0.1', split_streams=True)
+print('exit code:', exit_code)
+print('stdout', stdout)
+print('stderr', stderr)
+```
+
 #### Other arguments
 
 `command_runner` takes **any** argument that `subprocess.Popen()` would take.
 
 It also uses the following standard arguments:
- - command: The command, doesn't need to be a list, a simple string works
- - valid_exit_codes: List of exit codes which won't trigger error logs
- - timeout: seconds before a process tree is killed forcefully, defaults to 3600
- - shell: Shall we use the cmd.exe or /usr/bin/env shell for command execution, defaults to False
- - encoding: Which text encoding the command produces, defaults to cp437 under Windows and utf-8 under Linux
- - stdout: Optional path to filename where to dump stdout, or queue where to write stdout, or callback function which is called when stdout has output
- - stderr: Optional path to filename where to dump stderr, or queue where to write stderr, or callback function which is called when stderr has output
- - windows_no_window: Shall a command create a console window (MS Windows only), defaults to False
- - live_output: Print output to stdout while executing command, defaults to False
- - method: Accepts 'poller' or 'monitor' stdout capture and timeout monitoring methods
- - check interval: Defaults to 0.05 seconds, which is the time between stream readings and timeout checks
- - stop_on: Optional function that when returns True stops command_runner execution
- - process_callback: Optional function that will take command_runner spawned process as argument, in order to deal with process info outside of command_runner
- - close_fds: Like Popen, defaults to True on Linux and False on Windows
- - universal_newlines: Like Popen, defaults to False
- - creation_flags: Like Popen, defaults to 0
- - bufsize: Like Popen, defaults to 16384. Line buffering (bufsize=1) is deprecated since Python 3.7
+ - command (str/list): The command, doesn't need to be a list, a simple string works
+ - valid_exit_codes (list): List of exit codes which won't trigger error logs
+ - timeout (int): seconds before a process tree is killed forcefully, defaults to 3600
+ - shell (bool): Shall we use the cmd.exe or /usr/bin/env shell for command execution, defaults to False
+ - encoding (str): Which text encoding the command produces, defaults to cp437 under Windows and utf-8 under Linux
+ - stdout (str/queue.Queue/function/False/None): Optional path to filename where to dump stdout, or queue where to write stdout, or callback function which is called when stdout has output
+ - stderr (str/queue.Queue/function/False/None): Optional path to filename where to dump stderr, or queue where to write stderr, or callback function which is called when stderr has output
+ - split_streams (bool): Split stdout and stderr into two separate results
+ - windows_no_window (bool): Shall a command create a console window (MS Windows only), defaults to False
+ - live_output (bool): Print output to stdout while executing command, defaults to False
+ - method (str): Accepts 'poller' or 'monitor' stdout capture and timeout monitoring methods
+ - check interval (float): Defaults to 0.05 seconds, which is the time between stream readings and timeout checks
+ - stop_on (function): Optional function that when returns True stops command_runner execution
+ - process_callback (function): Optional function that will take command_runner spawned process as argument, in order to deal with process info outside of command_runner
+ - close_fds (bool): Like Popen, defaults to True on Linux and False on Windows
+ - universal_newlines (bool): Like Popen, defaults to False
+ - creation_flags (int): Like Popen, defaults to 0
+ - bufsize (int): Like Popen, defaults to 16384. Line buffering (bufsize=1) is deprecated since Python 3.7
+
+**Note that ALL other subprocess.Popen arguments are supported, since they are directly passed to subprocess.**
 
 ## UAC Elevation / sudo elevation
 

--- a/README.md
+++ b/README.md
@@ -151,19 +151,26 @@ logging.getLogger('command_runner').setLevel(logging.ERROR)
 `command_runner` allows two different process output capture methods:
 
 `method='monitor'` which is default:
- - A thread is spawned in order to check timeout and kill process if needed
+ - A thread is spawned in order to check stop conditions and kill process if needed
  - A main loop waits for the process to finish, then uses proc.communicate() to get it's output
- - Pros: less CPU usage
- - Cons: cannot read partial output on KeyboardInterrupt (still works for partial timeout output)
+ - Pros:
+     - less CPU usage
+     - less threads
+ - Cons:
+     - cannot read partial output on KeyboardInterrupt or stop_on (still works for partial timeout output)
+     - cannot use queues or callback functions redirectors
+     - is 0.1 seconds slower than poller method
+     
 
 `method='poller'`:
- - A thread is spawned and reads stdout pipe into a output queue
- - A poller loop reads from the output queue, checks timeout and kills process if needed
+ - A thread is spawned and reads stdout/stderr pipes into output queues
+ - A poller loop reads from the output queues, checks stop conditions and kills process if needed
  - Pros: 
       - Reads on the fly, allowing interactive commands (is also used with `live_output=True`)
-      - Allows stdout/stderr output to be written live to callback functions, queues or files 
- - Cons: Lightly higher CPU usage
-
+      - Allows stdout/stderr output to be written live to callback functions, queues or files (useful when threaded)
+      - is 0.1 seconds faster than monitor method, is preferred method for fast batch runnings
+ - Cons:
+      - lightly higher CPU usage
 
 Example:
 ```python
@@ -363,6 +370,7 @@ print('exit code:', exit_code)
 print('stdout', stdout)
 print('stderr', stderr)
 ```
+
 
 #### Other arguments
 

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -21,8 +21,8 @@ __intname__ = "command_runner"
 __author__ = "Orsiris de Jong"
 __copyright__ = "Copyright (C) 2015-2022 Orsiris de Jong"
 __licence__ = "BSD 3 Clause"
-__version__ = "1.4.0-rc2"
-__build__ = "2022052501"
+__version__ = "1.4.0"
+__build__ = "2022052901"
 __compat__ = "python2.7+"
 
 import io

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -371,8 +371,11 @@ def command_runner(
 
     # Fix when unix command was given as single string
     # This is more secure than setting shell=True
-    if os.name == "posix" and shell is False and isinstance(command, str):
-        command = shlex.split(command)
+    if os.name == "posix":
+        if not shell and isinstance(command, str):
+            command = shlex.split(command)
+        elif shell and isinstance(command, list):
+            command = ' '.join(command)
 
     # Set default values for kwargs
     errors = kwargs.pop(

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -412,7 +412,11 @@ def command_runner(
         _stdout = open(stdout, "wb")
         stdout_destination = "file"
     elif stdout is False:
-        _stdout = subprocess.DEVNULL
+        # Python 2.7 does not have subprocess.DEVNULL, hence we need to use a file descriptor
+        try:
+            _stdout = subprocess.DEVNULL
+        except AttributeError:
+            _stdout = PIPE
         stdout_destination = None
     else:
         # We will send anything to given stdout pipe
@@ -430,7 +434,10 @@ def command_runner(
         _stderr = open(stderr, "wb")
         stderr_destination = "file"
     elif stderr is False:
-        _stderr = subprocess.DEVNULL
+        try:
+            _stderr = subprocess.DEVNULL
+        except AttributeError:
+            _stderr = PIPE
         stderr_destination = None
     elif stderr is not None:
         _stderr = stderr
@@ -878,9 +885,9 @@ def command_runner(
         if stderr_destination == "file":
             _stderr.close()
 
-    logger.debug("STDOUT: " + output_stdout if output_stdout else "")
+    logger.debug("STDOUT: " + to_encoding(output_stdout, encoding, errors) if output_stdout else "None")
     if stderr_destination not in ["stdout", None]:
-        logger.debug("STDERR: " + output_stderr if output_stderr else "")
+        logger.debug("STDERR: " + to_encoding(output_stderr, encoding, errors) if output_stderr else "None")
 
     # Make sure we send a simple queue end before leaving to make any queue read process will stop regardless
     # of command_runner state (useful when launching with queue and method poller which isn't supposed to write queues)

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -675,7 +675,7 @@ def command_runner(
                 else:
                     break
                 # We still need to use process.communicate() in this loop so we don't get stuck
-                # with poll() is not None even after process is finished
+                # with poll() is not None even after process is finished, when using shell=True
                 # Behavior validated on python 3.7
                 try:
                     output_stdout, output_stderr = process.communicate()

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -737,7 +737,17 @@ def command_runner(
 
     # After all the stuff above, here's finally the function main entry point
     output_stdout = output_stderr = None
+
     try:
+        # Don't allow monitor method when stdout or stderr is callback/queue redirection (makes no sense)
+        if stdout_destination in [
+            "callback",
+            "queue",
+        ] or stderr_destination in ["callback", "queue"]:
+            raise ValueError(
+                'Cannot use callback or queue destination in monitor mode. Please use method="poller" argument.'
+            )
+
         # Finally, we won't use encoding & errors arguments for Popen
         # since it would defeat the idea of binary pipe reading in live mode
 
@@ -789,14 +799,6 @@ def command_runner(
                         process, timeout, encoding, errors
                     )
             else:
-                # Don't allow monitor method when stdout or stderr is callback/queue redirection (makes no sense)
-                if stdout_destination in [
-                    "callback",
-                    "queue",
-                ] or stderr_destination in ["callback", "queue"]:
-                    raise ValueError(
-                        'Cannot use callback or queue destination in monitor mode. Please use method="poller" argument.'
-                    )
                 if split_streams:
                     exit_code, output_stdout, output_stderr = _monitor_process(
                         process, timeout, encoding, errors

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -519,7 +519,6 @@ def command_runner(
         begin_time = datetime.now()
         output_stdout = output_stderr = ""
 
-
         try:
             if stdout_destination is not None:
                 stdout_read_queue = True
@@ -762,9 +761,13 @@ def command_runner(
                 process_callback(process)
             if method == "poller" or live_output and _stdout is not False:
                 if split_streams:
-                    exit_code, output_stdout, output_stderr = _poll_process(process, timeout, encoding, errors)
+                    exit_code, output_stdout, output_stderr = _poll_process(
+                        process, timeout, encoding, errors
+                    )
                 else:
-                    exit_code, output_stdout = _poll_process(process, timeout, encoding, errors)
+                    exit_code, output_stdout = _poll_process(
+                        process, timeout, encoding, errors
+                    )
             else:
                 # Don't allow monitor method when stdout or stderr is callback/queue redirection (makes no sense)
                 if stdout_destination in [
@@ -775,9 +778,13 @@ def command_runner(
                         'Cannot use callback or queue destination in monitor mode. Please use method="poller" argument.'
                     )
                 if split_streams:
-                    exit_code, output_stdout, output_stderr = _monitor_process(process, timeout, encoding, errors)
+                    exit_code, output_stdout, output_stderr = _monitor_process(
+                        process, timeout, encoding, errors
+                    )
                 else:
-                    exit_code, output_stdout = _monitor_process(process, timeout, encoding, errors)
+                    exit_code, output_stdout = _monitor_process(
+                        process, timeout, encoding, errors
+                    )
         except KbdInterruptGetOutput as exc:
             exit_code = -252
             output_stdout = "KeyboardInterrupted. Partial output\n{}".format(exc.output)
@@ -791,7 +798,6 @@ def command_runner(
                 _stderr.write(output_stderr.encode(encoding, errors=errors))
             elif stdout_destination == "file" and output_stderr:
                 _stdout.write(output_stderr.encode(encoding, errors=errors))
-
 
         logger.debug(
             'Command "{}" returned with exit code "{}". Command output was:'.format(
@@ -872,9 +878,9 @@ def command_runner(
         if stderr_destination == "file":
             _stderr.close()
 
-    logger.debug('STDOUT: ' + output_stdout if output_stdout else "")
-    if stderr_destination not in ['stdout', None]:
-        logger.debug('STDERR: ' + output_stderr if output_stderr else "")
+    logger.debug("STDOUT: " + output_stdout if output_stdout else "")
+    if stderr_destination not in ["stdout", None]:
+        logger.debug("STDERR: " + output_stderr if output_stderr else "")
 
     # Make sure we send a simple queue end before leaving to make any queue read process will stop regardless
     # of command_runner state (useful when launching with queue and method poller which isn't supposed to write queues)

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -917,9 +917,11 @@ def command_runner(
     # With polling, we return None if nothing has been send to the queues
     # With monitor, process.communicate() will result in '' even if nothing has been sent
     # Let's fix this here
-    if stdout_destination is None or (output_stdout and len(output_stdout) == 0):
+    # Python 2.7 will return False to u'' == '' (UnicodeWarning: Unicode equal comparison failed)
+    # so we have to make the following statement
+    if stdout_destination is None or (output_stdout is not None and len(output_stdout) == 0):
         output_stdout = None
-    if stderr_destination is None or (output_stderr and len(output_stderr) == 0):
+    if stderr_destination is None or (output_stderr is not None and len(output_stderr) == 0):
         output_stderr = None
 
     if split_streams:

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -673,13 +673,14 @@ def command_runner(
                     pass
                 else:
                     break
+                # WIP TODO: Do we still need this since we use must_stop which was already a mutable before
                 # We still need to use process.communicate() in this loop so we don't get stuck
                 # with poll() is not None even after process is finished
-                try:
-                    output_stdout, output_stderr = process.communicate()
+                #try:
+                #    output_stdout, output_stderr = process.communicate()
                 # ValueError is raised on closed IO file
-                except (TimeoutExpired, ValueError):
-                    pass
+                #except (TimeoutExpired, ValueError):
+                #    pass
             exit_code = process.poll()
 
             try:

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -872,9 +872,9 @@ def command_runner(
         if stderr_destination == "file":
             _stderr.close()
 
-    logger.debug('STDOUT:', output_stdout)
+    logger.debug('STDOUT: ' + output_stdout if output_stdout else "")
     if stderr_destination not in ['stdout', None]:
-        logger.debug('STDERR:', output_stderr)
+        logger.debug('STDERR: ' + output_stderr if output_stderr else "")
 
     # Make sure we send a simple queue end before leaving to make any queue read process will stop regardless
     # of command_runner state (useful when launching with queue and method poller which isn't supposed to write queues)

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -375,7 +375,7 @@ def command_runner(
         if not shell and isinstance(command, str):
             command = shlex.split(command)
         elif shell and isinstance(command, list):
-            command = ' '.join(command)
+            command = " ".join(command)
 
     # Set default values for kwargs
     errors = kwargs.pop(
@@ -740,10 +740,14 @@ def command_runner(
 
     try:
         # Don't allow monitor method when stdout or stderr is callback/queue redirection (makes no sense)
-        if method == "monitor" and (stdout_destination in [
-            "callback",
-            "queue",
-        ] or stderr_destination in ["callback", "queue"]):
+        if method == "monitor" and (
+            stdout_destination
+            in [
+                "callback",
+                "queue",
+            ]
+            or stderr_destination in ["callback", "queue"]
+        ):
             raise ValueError(
                 'Cannot use callback or queue destination in monitor mode. Please use method="poller" argument.'
             )
@@ -926,9 +930,13 @@ def command_runner(
     # Let's fix this here
     # Python 2.7 will return False to u'' == '' (UnicodeWarning: Unicode equal comparison failed)
     # so we have to make the following statement
-    if stdout_destination is None or (output_stdout is not None and len(output_stdout) == 0):
+    if stdout_destination is None or (
+        output_stdout is not None and len(output_stdout) == 0
+    ):
         output_stdout = None
-    if stderr_destination is None or (output_stderr is not None and len(output_stderr) == 0):
+    if stderr_destination is None or (
+        output_stderr is not None and len(output_stderr) == 0
+    ):
         output_stderr = None
 
     if split_streams:

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -696,8 +696,6 @@ def command_runner(
             if output_stderr_end and len(output_stderr_end) > 0:
                 output_stderr = output_stderr_end
 
-
-
             if split_streams:
                 if stdout_destination is not None:
                     output_stdout = to_encoding(output_stdout, encoding, errors)
@@ -887,7 +885,7 @@ def command_runner(
         logger.error(
             'Command "{}" failed for unknown reasons: {}'.format(
                 command, to_encoding(exc.__str__(), encoding, errors)
-            ), exc_info=True
+            ),
         )
         logger.debug("Error:", exc_info=True)
         exit_code, output_stdout = (-255, to_encoding(exc.__str__(), encoding, errors))
@@ -897,9 +895,17 @@ def command_runner(
         if stderr_destination == "file":
             _stderr.close()
 
-    logger.debug("STDOUT: " + to_encoding(output_stdout, encoding, errors) if output_stdout else "None")
+    logger.debug(
+        "STDOUT: " + to_encoding(output_stdout, encoding, errors)
+        if output_stdout
+        else "None"
+    )
     if stderr_destination not in ["stdout", None]:
-        logger.debug("STDERR: " + to_encoding(output_stderr, encoding, errors) if output_stderr else "None")
+        logger.debug(
+            "STDERR: " + to_encoding(output_stderr, encoding, errors)
+            if output_stderr
+            else "None"
+        )
 
     # Make sure we send a simple queue end before leaving to make any queue read process will stop regardless
     # of command_runner state (useful when launching with queue and method poller which isn't supposed to write queues)

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -505,7 +505,9 @@ def command_runner(
 
             if timeout and (datetime.now() - begin_time).total_seconds() > timeout:
                 kill_childs_mod(process.pid, itself=True, soft_kill=False)
-                raise TimeoutExpired(process, timeout, _get_error_output(output_stdout, output_stderr))
+                raise TimeoutExpired(
+                    process, timeout, _get_error_output(output_stdout, output_stderr)
+                )
             if stop_on and stop_on():
                 kill_childs_mod(process.pid, itself=True, soft_kill=False)
                 raise StopOnInterrupt(_get_error_output(output_stdout, output_stderr))
@@ -516,7 +518,9 @@ def command_runner(
             output_stderr = None if stderr_destination is None else ""
         else:
             output_stdout = (
-                None if (stdout_destination is None and stderr_destination is None) else ""
+                None
+                if (stdout_destination is None and stderr_destination is None)
+                else ""
             )
             output_stderr = None if stderr_destination is None else ""
 
@@ -601,7 +605,6 @@ def command_runner(
 
         except KeyboardInterrupt:
             raise KbdInterruptGetOutput(_get_error_output(output_stdout, output_stderr))
-
 
     def _timeout_check_thread(
         process,  # type: Union[subprocess.Popen[str], subprocess.Popen]
@@ -701,7 +704,9 @@ def command_runner(
             except queue.Empty:
                 pass
             if must_stop == "T":
-                raise TimeoutExpired(process, timeout, _get_error_output(output_stdout, output_stderr))
+                raise TimeoutExpired(
+                    process, timeout, _get_error_output(output_stdout, output_stderr)
+                )
             elif must_stop == "S":
                 raise StopOnInterrupt(_get_error_output(output_stdout, output_stderr))
             elif must_stop is not False:
@@ -714,7 +719,6 @@ def command_runner(
                 return exit_code, output_stdout
         except KeyboardInterrupt:
             raise KbdInterruptGetOutput(_get_error_output(output_stdout, output_stderr))
-
 
     try:
         # Finally, we won't use encoding & errors arguments for Popen

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -740,10 +740,10 @@ def command_runner(
 
     try:
         # Don't allow monitor method when stdout or stderr is callback/queue redirection (makes no sense)
-        if stdout_destination in [
+        if method == "monitor" and (stdout_destination in [
             "callback",
             "queue",
-        ] or stderr_destination in ["callback", "queue"]:
+        ] or stderr_destination in ["callback", "queue"]):
             raise ValueError(
                 'Cannot use callback or queue destination in monitor mode. Please use method="poller" argument.'
             )
@@ -798,7 +798,7 @@ def command_runner(
                     exit_code, output_stdout = _poll_process(
                         process, timeout, encoding, errors
                     )
-            else:
+            elif method == "monitor":
                 if split_streams:
                     exit_code, output_stdout, output_stderr = _monitor_process(
                         process, timeout, encoding, errors
@@ -807,6 +807,8 @@ def command_runner(
                     exit_code, output_stdout = _monitor_process(
                         process, timeout, encoding, errors
                     )
+            else:
+                raise ValueError("Unknown method {} provided.".format(method))
         except KbdInterruptGetOutput as exc:
             exit_code = -252
             output_stdout = "KeyboardInterrupted. Partial output\n{}".format(exc.output)

--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -917,9 +917,9 @@ def command_runner(
     # With polling, we return None if nothing has been send to the queues
     # With monitor, process.communicate() will result in '' even if nothing has been sent
     # Let's fix this here
-    if output_stdout == "":
+    if stdout_destination is None or (output_stdout and len(output_stdout) == 0):
         output_stdout = None
-    if output_stderr == "":
+    if stderr_destination is None or (output_stderr and len(output_stderr) == 0):
         output_stderr = None
 
     if split_streams:

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -580,6 +580,9 @@ def test_split_streams():
                 assert False, 'We should have too many values to unpack here'
         
             exit_code, stdout, stderr = command_runner(cmd, method=method, shell=True, split_streams=True)
+            print('exit_code:', exit_code)
+            print('STDOUT:', stdout)
+            print('STDERR:', stderr)
             if cmd == PING_CMD:
                 assert exit_code == 0, 'Exit code should be 0 for ping command with method {}'.format(method)
                 assert '127.0.0.1' in stdout

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -584,7 +584,8 @@ def test_null_redir():
         print(exit_code)
         print('STDOUT:', stdout)
         print('STDERR:', stderr)
-        assert '0.0.0.0' not in output, 'We should not get error output from here'
+        assert '0.0.0.0' not in stdout, 'We should not get error output from here'
+        assert '0.0.0.0' not in stderr, 'We should not get error output from here'
 
 
 def test_split_streams():

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -345,6 +345,9 @@ def test_queue_output():
         for stream in streams:
             output_queue = queue.Queue()
             for method in methods:
+                # No need to make alot of monitor mode checks in queue mode
+                if method == 'monitor' and i > 1:
+                    continue
                 stream_output = ""
                 stream_args = {stream: output_queue}
                 output_queue.queue.clear()

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -553,15 +553,36 @@ def test_powershell_output():
 
 
 def test_null_redir():
-    exit_code, output = command_runner(PING_CMD, stdout=False)
-    assert output is None, 'We should not have any output here'
-    print(exit_code)
-    print('OUTPUT:', output)
+    for method in methods:
+        print('method={}'.format(method))
+        exit_code, output = command_runner(PING_CMD, stdout=False)
+        print(exit_code)
+        print('OUTPUT:', output)
+        assert output is None, 'We should not have any output here'
 
-    exit_code, output = command_runner(PING_CMD_AND_FAILURE, shell=True, stderr=False)
-    assert '0.0.0.0' not in output, 'We should not get error output from here'
-    print(exit_code)
-    print('OUTPUT:', output)
+
+        exit_code, output = command_runner(PING_CMD_AND_FAILURE, shell=True, stderr=False)
+        print(exit_code)
+        print('OUTPUT:', output)
+        assert '0.0.0.0' not in output, 'We should not get error output from here'
+
+
+    for method in methods:
+        print('method={}'.format(method))
+        exit_code, stdout, stderr = command_runner(PING_CMD, split_streams=True, stdout=False, stderr=False)
+        print(exit_code)
+        print('STDOUT:', stdout)
+        print('STDERR:', stderr)
+        assert stdout is None, 'We should not have any output here'
+        assert stderr is None
+
+
+        exit_code, stdout, stderr = command_runner(PING_CMD_AND_FAILURE, shell=True, split_streams=True, stdout=False, stderr=False)
+        print(exit_code)
+        print('STDOUT:', stdout)
+        print('STDERR:', stderr)
+        assert '0.0.0.0' not in output, 'We should not get error output from here'
+
 
 def test_split_streams():
     """

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -576,16 +576,16 @@ def test_null_redir():
         print(exit_code)
         print('STDOUT:', stdout)
         print('STDERR:', stderr)
-        assert stdout is None, 'We should not have any output here'
-        assert stderr is None
+        assert stdout is None, 'We should not have any output from stdout'
+        assert stderr is None, 'We should not have any output from stderr'
 
 
         exit_code, stdout, stderr = command_runner(PING_CMD_AND_FAILURE, shell=True, split_streams=True, stdout=False, stderr=False)
         print(exit_code)
         print('STDOUT:', stdout)
         print('STDERR:', stderr)
-        assert '0.0.0.0' not in stdout, 'We should not get error output from here'
-        assert '0.0.0.0' not in stderr, 'We should not get error output from here'
+        assert stdout is None, 'We should not have any output from stdout'
+        assert stderr is None, 'We should not have any output from stderr'
 
 
 def test_split_streams():

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -18,7 +18,7 @@ __intname__ = 'command_runner_tests'
 __author__ = 'Orsiris de Jong'
 __copyright__ = 'Copyright (C) 2015-2022 Orsiris de Jong'
 __licence__ = 'BSD 3 Clause'
-__build__ = '2022052401'
+__build__ = '2022052901'
 
 
 import re
@@ -68,7 +68,6 @@ else:
     PING_CMD_AND_FAILURE = 'ping 0.0.0.0 -c 2 1>&2; ping 127.0.0.1 -c 2'
     PRINT_FILE_CMD = 'cat {}'.format(test_filename)
     PING_FAILURE = 'ping 0.0.0.0 -c 2 1>&2'
-    # TODO shlex.split(command, posix=True) test for Linux
 
 
 ELAPSED_TIME = timestamp(datetime.now())
@@ -379,8 +378,9 @@ def test_queue_output():
                                                                                                           output)
                     # Since we redirect STDOUT to STDERR
                     if stream == 'stdout':
-                        # TODO: test stderr stream output
-                        assert stream_output == output, 'Queue output should contain same result as output'
+                        assert stream_output == output, 'stdout queue output should contain same result as output'
+                    if stream == 'stderr':
+                        assert len(stream_output) == 0, 'stderr queue output should be empty'
                 else:
                     assert exit_code == -250, 'stream_queue exit_code is bogus. method={}, exit_code: {}, output: {}'.format(
                         method, exit_code,

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -598,7 +598,7 @@ def test_split_streams():
                 # Should generate a valueError
                 pass
             except Exception as exc:
-                assert False, 'We should have too many values to unpack here'
+                assert False, 'We should have too many values to unpack here: {}'.format(exc)
         
             exit_code, stdout, stderr = command_runner(cmd, method=method, shell=True, split_streams=True)
             print('exit_code:', exit_code)

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -407,7 +407,6 @@ def test_queue_non_threaded_command_runner():
                     stream_output['value'] += line
                     # ADD YOUR LIVE CODE HERE
         return stream_output
-        # TODO assert test here
 
 
     for i in range(0, 20):


### PR DESCRIPTION
- Add `split_streams=[bool]` functionnalty
- Fix missing subprocess.DEVNULL for python 2.7
- Ensure we always get None as stream result when nothing was sent from process (Python 2.7)
- Fix unix command as list didn't work with `shell=True`