### PR TITLE
use standard ping(8) arguments in tests

### DIFF
--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -54,11 +54,11 @@ if os.name == 'nt':
     PRINT_FILE_CMD = 'type {}'.format(test_filename)
 else:
     ENCODING = 'utf-8'
-    PING_CMD = ['ping', '127.0.0.1', '-c', '4']
-    PING_CMD_REDIR = 'ping 127.0.0.1 -c 4 1>&2'
-    PING_CMD_AND_FAILURE = 'ping 0.0.0.0 -c 2 1>&2; ping 127.0.0.1 -c 2'
+    PING_CMD = ['ping', '-c', '4', '127.0.0.1']
+    PING_CMD_REDIR = 'ping -c 4 127.0.0.1 1>&2'
+    PING_CMD_AND_FAILURE = 'ping -c 2 0.0.0.0 1>&2; ping -c 2 127.0.0.1'
     PRINT_FILE_CMD = 'cat {}'.format(test_filename)
-    PING_FAILURE = 'ping 0.0.0.0 -c 2 1>&2'
+    PING_FAILURE = 'ping -c 2 0.0.0.0 1>&2'
 
 
 ELAPSED_TIME = timestamp(datetime.now())


### PR DESCRIPTION
Change the command line for ping in tests.
Traditional UNIX ping only accepts flags before the address.