### PR TITLE
use sleep instead of ping as a timer on !windows

### DIFF
--- a/command_runner/__init__.py
+++ b/command_runner/__init__.py
@@ -987,7 +987,7 @@ def deferred_command(command, defer_time=300):
     if os.name == "nt":
         deferrer = "ping 127.0.0.1 -n {} > NUL & ".format(defer_time)
     else:
-        deferrer = "ping 127.0.0.1 -c {} > /dev/null && ".format(defer_time)
+        deferrer = "sleep {} && ".format(defer_time)
 
     # We'll create a independent shell process that will not be attached to any stdio interface
     # Our command shall be a single string since shell=True


### PR DESCRIPTION
sleep is almost certainly as likely to exist as ping (and in some cases, more likely).

if this is not acceptable then the ping syntax should at least change to place
the arguments before the IP address, as per #18